### PR TITLE
Don't overwrite self.tx_pulselength if already set

### DIFF
--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -100,7 +100,7 @@ class RFDevice:
             self.tx_proto = 1
         if tx_pulselength:
             self.tx_pulselength = tx_pulselength
-        else:
+        elif not self.tx_pulselength:
             self.tx_pulselength = PROTOCOLS[self.tx_proto].pulselength
         rawcode = format(code, '#0{}b'.format(self.tx_length + 2))[2:]
         _LOGGER.debug("TX code: " + str(code))


### PR DESCRIPTION
Currently this will overwrite `self.tx_pulselength` with the default value for the protocol instead of using the value it was initialized with:

```python
dev = RFDevice(17, tx_pulselength=19)
dev.enable_tx()
dev.tx_code(4478268)
```

This small change makes sure the RFDevice respects `tx_pulselength` if it has already been set.