### PR TITLE
more accurate sleep

### DIFF
--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -152,9 +152,9 @@ class RFDevice:
             _LOGGER.error("TX is not enabled, not sending data")
             return False
         GPIO.output(self.gpio, GPIO.HIGH)
-        time.sleep((highpulses * self.tx_pulselength) / 1000000)
+        self._sleep((highpulses * self.tx_pulselength) / 1000000)
         GPIO.output(self.gpio, GPIO.LOW)
-        time.sleep((lowpulses * self.tx_pulselength) / 1000000)
+        self._sleep((lowpulses * self.tx_pulselength) / 1000000)
         return True
 
     def enable_rx(self):
@@ -229,3 +229,9 @@ class RFDevice:
             return True
 
         return False
+           
+    def _sleep(self, delay):      
+        _delay = delay / 100
+        end = time.time() + delay - _delay
+        while time.time() < end:
+            time.sleep(_delay)


### PR DESCRIPTION
I had problems with running the script in a docker container (milaq#16). It never reached the expected pulselength, was always too long.
But I could workaround the problem by use a more accurate sleep by dividing it.
The solution is not really nice but it works...