### PR TITLE
Update rpi_rf.py: Added 32-bit TX code compatibility

### DIFF
--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -102,6 +102,13 @@ class RFDevice:
             self.tx_pulselength = tx_pulselength
         else:
             self.tx_pulselength = PROTOCOLS[self.tx_proto].pulselength
+        
+        """Set tx_length depending on code value"""
+        if (code < 16777216):
+            self.tx_length = 24
+        else:
+            self.tx_length = 32
+        
         rawcode = format(code, '#0{}b'.format(self.tx_length + 2))[2:]
         _LOGGER.debug("TX code: " + str(code))
         return self.tx_bin(rawcode)


### PR DESCRIPTION
In the actual release of rpi_rf.py I can't use my RF switches because theirs protocol is 32-bit and not 24-bit that is common for 433 MHz RF.

I found the solution in a comment in a youtube video (https://www.youtube.com/watch?v=5UUazFbK-Hg) written by the user Michael McILroy:

> I had previously made a comment regarding changing the tx_length in rpi_rf.py from 24 to 32 to allow some switches to work that have a longer digital code.
> 
> I have now purchased a 12 VDC 433 MHz 4 channel relay switch so that I could switch my outdoor garden and deck lights on and off.
> 
> Now for the different switches I need both the 24 and 32 tx_length.
> 
> Here is the modification to rpi_rf.py that will determine this based on the code number that is to be transmitted. 
> 
> ```
>     def tx_code(self, code, tx_proto=None, tx_pulselength=None):
>         """
>         Send a decimal code.
> 
>         Optionally set protocol and pulselength.
>         When none given reset to default protocol and pulselength.
>         """
>         if tx_proto:
>             self.tx_proto = tx_proto
>         else:
>             self.tx_proto = 1
>         if tx_pulselength:
>             self.tx_pulselength = tx_pulselength
>         else:
>             self.tx_pulselength = PROTOCOLS[self.tx_proto].pulselength
> 
>   # Set tx_length depending on code value
>         if (code < 16777216):
>             self.tx_length = 24
>         else:
>             self.tx_length = 32
> 
>         rawcode = format(code, '#0{}b'.format(self.tx_length + 2))[2:]
>         _LOGGER.debug("TX code: " + str(code))
>         return self.tx_bin(rawcode)
> ```
> 
> This is the piece of extra code that is inserted into the tx_code function
> 
> ```
>  # Set tx_length depending on code value
>         if (code < 16777216):
>             self.tx_length = 24
>         else:
>             self.tx_length = 32
> ```
> 
> When you update your home assistant this will get over written so you'll need to update it manually again.

I tested it in the Raspbian distribution (in other micro-sd for Raspberyy Pi) and it works!