### PR TITLE
Add bitlength parameter

### DIFF
--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -91,8 +91,8 @@ class RFDevice:
         """
         Send a decimal code.
 
-        Optionally set protocol, pulselength and (code) lenght.
-        When none given reset to default protocol and pulselength and set to 24 bit (code) lenght.
+        Optionally set protocol, pulselength and (code) length.
+        When none given reset to default protocol and pulselength and set to 24 bit (code) length.
         """
         if tx_proto:
             self.tx_proto = tx_proto

--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -87,27 +87,40 @@ class RFDevice:
             _LOGGER.debug("TX disabled")
         return True
 
-    def tx_code(self, code, tx_proto=None, tx_pulselength=None):
+    def tx_code(self, code, tx_proto=None, tx_pulselength=None, tx_length=None):
         """
         Send a decimal code.
 
-        Optionally set protocol and pulselength.
-        When none given reset to default protocol and pulselength.
+        Optionally set protocol, pulselength and (code) lenght.
+        When none given reset to default protocol and pulselength and set to 24 bit (code) lenght.
         """
         if tx_proto:
             self.tx_proto = tx_proto
         else:
             self.tx_proto = 1
+
         if tx_pulselength:
             self.tx_pulselength = tx_pulselength
         elif not self.tx_pulselength:
             self.tx_pulselength = PROTOCOLS[self.tx_proto].pulselength
+
+        """Set tx_length depending on code value"""
+        if tx_length:
+            self.tx_length = tx_length
+        elif (code < 16777216):
+            self.tx_length = 24
+        else:
+            self.tx_length = 32
+
         rawcode = format(code, '#0{}b'.format(self.tx_length + 2))[2:]
         _LOGGER.debug("TX code: " + str(code))
         return self.tx_bin(rawcode)
 
-    def tx_bin(self, rawcode):
+    def tx_bin(self, rawcode, tx_length=None):
         """Send a binary code."""
+        if tx_length:
+            self.tx_length = tx_length
+
         _LOGGER.debug("TX bin: " + str(rawcode))
         for _ in range(0, self.tx_repeat):
             for byte in range(0, self.tx_length):

--- a/scripts/rpi-rf_send
+++ b/scripts/rpi-rf_send
@@ -17,6 +17,8 @@ parser.add_argument('-p', dest='pulselength', type=int, default=None,
                     help="Pulselength (Default: 350)")
 parser.add_argument('-t', dest='protocol', type=int, default=None,
                     help="Protocol (Default: 1)")
+parser.add_argument('-l', dest='length', type=int, default=None,
+                    help="Codelength (Default: 24)")
 args = parser.parse_args()
 
 rfdevice = RFDevice(args.gpio)
@@ -30,9 +32,15 @@ if args.pulselength:
     pulselength = args.pulselength
 else:
     pulselength = "default"
+if args.length:
+    length = args.length
+else:
+    length = "default"
+
 logging.info(str(args.code) +
              " [protocol: " + str(protocol) +
-             ", pulselength: " + str(pulselength) + "]")
+             ", pulselength: " + str(pulselength) +
+             ", length: " + str(length) + "]")
 
-rfdevice.tx_code(args.code, args.protocol, args.pulselength)
+rfdevice.tx_code(args.code, args.protocol, args.pulselength, args.length)
 rfdevice.cleanup()


### PR DESCRIPTION
Some new 433 MHz RF switches use codes with 32 bit (against the usual 24 bit): this commit allows user to specify the code length.
In addition, a verification is implemented that automatically sets the length to 32 bit when a user tries to send a code greater than 24 bits.