### PR TITLE
Improve receiving quality

### DIFF
--- a/rpi_rf/rpi_rf.py
+++ b/rpi_rf/rpi_rf.py
@@ -206,7 +206,7 @@ class RFDevice:
         duration = timestamp - self._rx_last_timestamp
 
         if duration > 5000:
-            if duration - self._rx_timings[0] < 200:
+            if abs(duration - self._rx_timings[0]) < 200:
                 self._rx_repeat_count += 1
                 self._rx_change_count -= 1
                 if self._rx_repeat_count == 2:
@@ -231,11 +231,11 @@ class RFDevice:
         delay_tolerance = delay * self.rx_tolerance / 100
 
         for i in range(1, change_count, 2):
-            if (self._rx_timings[i] - delay * PROTOCOLS[pnum].zero_high < delay_tolerance and
-                    self._rx_timings[i+1] - delay * PROTOCOLS[pnum].zero_low < delay_tolerance):
+            if (abs(self._rx_timings[i] - delay * PROTOCOLS[pnum].zero_high) < delay_tolerance and
+                abs(self._rx_timings[i+1] - delay * PROTOCOLS[pnum].zero_low) < delay_tolerance):
                 code <<= 1
-            elif (self._rx_timings[i] - delay * PROTOCOLS[pnum].one_high < delay_tolerance and
-                  self._rx_timings[i+1] - delay * PROTOCOLS[pnum].one_low < delay_tolerance):
+            elif (abs(self._rx_timings[i] - delay * PROTOCOLS[pnum].one_high) < delay_tolerance and
+                  abs(self._rx_timings[i+1] - delay * PROTOCOLS[pnum].one_low) < delay_tolerance):
                 code <<= 1
                 code |= 1
             else:


### PR DESCRIPTION
I've found in rf_switch code that the difference can be positive and negative. So, I've tried to implement this and now I have no such noise level as before. 

Some log without abs call:
```
pi@hassbian:/usr/local/bin $ ./rpi-rf_receive
2018-12-26 06:56:05 - [INFO] rpi-rf_receive: Listening for codes on GPIO 27
2018-12-26 06:56:18 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 146, protocol 3]
2018-12-26 06:56:18 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 340, protocol 1]
2018-12-26 06:56:29 - [INFO] rpi-rf_receive: 0x0000000c [pulselength 270, protocol 3]
2018-12-26 06:57:00 - [INFO] rpi-rf_receive: 0x00000200 [pulselength 1003, protocol 4]
2018-12-26 06:57:00 - [INFO] rpi-rf_receive: 0x00000008 [pulselength 713, protocol 2]
2018-12-26 06:57:23 - [INFO] rpi-rf_receive: 0x00004000 [pulselength 1401, protocol 2]
2018-12-26 06:57:24 - [INFO] rpi-rf_receive: 0x00000048 [pulselength 1631, protocol 2]
2018-12-26 06:57:24 - [INFO] rpi-rf_receive: 0x00000042 [pulselength 1243, protocol 2]
2018-12-26 06:57:25 - [INFO] rpi-rf_receive: 0x00000008 [pulselength 1492, protocol 2]
2018-12-26 06:57:28 - [INFO] rpi-rf_receive: 0x00000010 [pulselength 1969, protocol 2]
2018-12-26 06:57:52 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 1208, protocol 4]
2018-12-26 06:58:16 - [INFO] rpi-rf_receive: 0x00000008 [pulselength 1714, protocol 5]
2018-12-26 06:58:19 - [INFO] rpi-rf_receive: 0x000001a0 [pulselength 951, protocol 4]
2018-12-26 06:58:19 - [INFO] rpi-rf_receive: 0x00000220 [pulselength 1032, protocol 1]
2018-12-26 06:58:19 - [INFO] rpi-rf_receive: 0x00000004 [pulselength 330, protocol 3]
2018-12-26 06:58:19 - [INFO] rpi-rf_receive: 0x00000003 [pulselength 472, protocol 1]
2018-12-26 06:58:19 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 1644, protocol 2]
2018-12-26 06:58:23 - [INFO] rpi-rf_receive: 0x000000c4 [pulselength 965, protocol 4]
2018-12-26 06:58:55 - [INFO] rpi-rf_receive: 0x00020000 [pulselength 1703, protocol 4]
2018-12-26 06:59:13 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 1962, protocol 4]
2018-12-26 06:59:13 - [INFO] rpi-rf_receive: 0x00000060 [pulselength 1500, protocol 4]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 1384, protocol 2]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000004 [pulselength 623, protocol 5]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 2484, protocol 2]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000800 [pulselength 1328, protocol 4]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000040 [pulselength 1366, protocol 2]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00000080 [pulselength 1858, protocol 4]
2018-12-26 06:59:14 - [INFO] rpi-rf_receive: 0x00004000 [pulselength 1102, protocol 2]
2018-12-26 06:59:28 - [INFO] rpi-rf_receive: 0x00080002 [pulselength 236, protocol 3]
2018-12-26 06:59:40 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 183, protocol 3]
2018-12-26 06:59:40 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 113, protocol 3]
2018-12-26 06:59:44 - [INFO] rpi-rf_receive: 0x00000020 [pulselength 1357, protocol 4]
2018-12-26 06:59:48 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 2021, protocol 4]
2018-12-26 06:59:48 - [INFO] rpi-rf_receive: 0x00000020 [pulselength 560, protocol 2]
2018-12-26 06:59:48 - [INFO] rpi-rf_receive: 0x00000001 [pulselength 1274, protocol 2]
2018-12-26 06:59:48 - [INFO] rpi-rf_receive: 0x00000080 [pulselength 1721, protocol 4]
2018-12-26 06:59:48 - [INFO] rpi-rf_receive: 0x00000004 [pulselength 182, protocol 3]
2018-12-26 07:00:06 - [INFO] rpi-rf_receive: 0x00000030 [pulselength 1209, protocol 4]
2018-12-26 07:00:06 - [INFO] rpi-rf_receive: 0x00100000 [pulselength 1531, protocol 4]
2018-12-26 07:00:06 - [INFO] rpi-rf_receive: 0x00000004 [pulselength 1815, protocol 2]
```

In the same enviroment with abs call I got much less noise:
```
pi@hassbian:/usr/local/bin $ ./rpi-rf_receive
2018-12-26 07:00:39 - [INFO] rpi-rf_receive: Listening for codes on GPIO 27
2018-12-26 07:02:16 - [INFO] rpi-rf_receive: 0x00000002 [pulselength 343, protocol 1]
2018-12-26 07:02:56 - [INFO] rpi-rf_receive: 0x0000001f [pulselength 877, protocol 6]
2018-12-26 07:06:34 - [INFO] rpi-rf_receive: 0x00000007 [pulselength 736, protocol 6]
2018-12-26 07:08:03 - [INFO] rpi-rf_receive: 0x0000000f [pulselength 1093, protocol 6]
```

